### PR TITLE
更新pandas新函数，df.as_matrix()为df.values

### DIFF
--- a/reportgen/report.py
+++ b/reportgen/report.py
@@ -159,7 +159,7 @@ def df_to_table(slide,df,left,top,width,height,index_names=False,columns_names=T
             cell=res.table.cell(col_index+columns_names,0)
             cell.text = '%s'%(col_name)
             #cell.text_frame.fit_text(max_size=12)
-    m = df.as_matrix()
+    m = df.values
     for row in range(rows):
         for col in range(cols):
             cell=res.table.cell(row+columns_names, col+index_names)


### PR DESCRIPTION
Pandas V1.0.0 2020年1月29日更新中淘汰了df.as_matrix(), 用df.values代替
更新日志：https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.0.0.html?highlight=as_matrix